### PR TITLE
fix: update rules mapping

### DIFF
--- a/output/act-axe-result.json
+++ b/output/act-axe-result.json
@@ -587,6 +587,1238 @@
       }
     },
     "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-audio_passed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-audio_failed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-audio_failed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-audio_failed_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-audio_failed_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-audio_inapplicable_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-audio_inapplicable_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-video_passed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-video_failed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-video_failed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-video_failed_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-video_failed_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-video_inapplicable_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-1-media-alternative-video_inapplicable_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
     "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-audio-captions_passed_example_1.html",
     "assertions": [
       {
@@ -1083,7 +2315,7 @@
       }
     },
     "@type": "WebPage",
-    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-Video-description-track_passed_example_1.html",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-audio-alternative_passed_example_1.html",
     "assertions": [
       {
         "@type": "Assertion",
@@ -1104,111 +2336,15 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures <video> elements have audio descriptions",
+          "info": "Ensures <video> elements have captions",
           "outcome": "earl:passed",
           "pointer": "video"
         }
-      }
-    ]
-  },
-  {
-    "@context": {
-      "@vocab": "http://www.w3.org/ns/earl#",
-      "earl": "http://www.w3.org/ns/earl#",
-      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
-      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
-      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
-      "dct": "http://purl.org/dc/terms#",
-      "sch": "https://schema.org/",
-      "doap": "http://usefulinc.com/ns/doap#",
-      "foaf": "http://xmlns.com/foaf/spec/#",
-      "WebPage": "sch:WebPage",
-      "url": "dct:source",
-      "assertions": {
-        "@reverse": "subject"
       },
-      "assertedBy": {
-        "@type": "@id"
-      },
-      "outcome": {
-        "@type": "@id"
-      },
-      "mode": {
-        "@type": "@id"
-      },
-      "pointer": {
-        "@type": "ptr:CSSSelectorPointer"
-      }
-    },
-    "@type": "WebPage",
-    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-Video-description-track_failed_example_1.html",
-    "assertions": [
-      {
-        "@type": "Assertion",
-        "mode": "earl:automatic",
-        "assertedBy": {
-          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
-          "@type": [
-            "earl:Assertor",
-            "earl:Software",
-            "doap:Project"
-          ],
-          "doap:name": "Axe",
-          "doap:vendor": {
-            "@id": "https://deque.com/",
-            "@type": "foaf:Organization",
-            "foaf:name": "Deque Systems"
-          }
-        },
-        "test": {
-          "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
-        },
-        "result": {
-          "@type": "TestResult",
-          "info": "Ensures <video> elements have audio descriptions",
-          "outcome": "earl:passed",
-          "pointer": "video"
-        }
-      }
-    ]
-  },
-  {
-    "@context": {
-      "@vocab": "http://www.w3.org/ns/earl#",
-      "earl": "http://www.w3.org/ns/earl#",
-      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
-      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
-      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
-      "dct": "http://purl.org/dc/terms#",
-      "sch": "https://schema.org/",
-      "doap": "http://usefulinc.com/ns/doap#",
-      "foaf": "http://xmlns.com/foaf/spec/#",
-      "WebPage": "sch:WebPage",
-      "url": "dct:source",
-      "assertions": {
-        "@reverse": "subject"
-      },
-      "assertedBy": {
-        "@type": "@id"
-      },
-      "outcome": {
-        "@type": "@id"
-      },
-      "mode": {
-        "@type": "@id"
-      },
-      "pointer": {
-        "@type": "ptr:CSSSelectorPointer"
-      }
-    },
-    "@type": "WebPage",
-    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-Video-description-track_inapplicable_example_1.html",
-    "assertions": [
       {
         "@type": "Assertion",
         "mode": "earl:automatic",
@@ -1269,8 +2405,36 @@
       }
     },
     "@type": "WebPage",
-    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-Video-description-track_inapplicable_example_2.html",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-audio-alternative_passed_example_2.html",
     "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
       {
         "@type": "Assertion",
         "mode": "earl:automatic",
@@ -1295,6 +2459,490 @@
         "result": {
           "@type": "TestResult",
           "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-audio-alternative_failed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-audio-alternative_failed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-audio-alternative_inapplicable_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-audio-alternative_inapplicable_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-captions_failed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-captions_failed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
           "outcome": "earl:passed",
           "pointer": "video"
         }
@@ -1331,8 +2979,408 @@
       }
     },
     "@type": "WebPage",
-    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-Video-description-track_inapplicable_example_3.html",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-captions_failed_example_3.html",
     "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-captions_failed_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-captions_inapplicable_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-captions_inapplicable_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:passed",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-captions_inapplicable_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-2-video-has-captions_inapplicable_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-video-audio-description_passed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
       {
         "@type": "Assertion",
         "mode": "earl:automatic",
@@ -1357,7 +3405,1087 @@
         "result": {
           "@type": "TestResult",
           "info": "Ensures <video> elements have audio descriptions",
-          "outcome": "earl:passed",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-video-audio-description_passed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "#ozplayer-1-ozplayer-video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "#ozplayer-1-ozplayer-video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-video-audio-description_failed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-video-audio-description_failed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-video-audio-description_failed_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "#ozplayer-1-ozplayer-video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "#ozplayer-1-ozplayer-video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-video-audio-description_inapplicable_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-video-audio-description_inapplicable_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-video-transcript_passed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-video-transcript_passed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-video-transcript_failed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-video-transcript_failed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-video-transcript_inapplicable_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC1-2-video-transcript_inapplicable_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-caption?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have captions",
+          "outcome": "earl:cantTell",
+          "pointer": "video"
+        }
+      },
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/video-description?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <video> elements have audio descriptions",
+          "outcome": "earl:cantTell",
           "pointer": "video"
         }
       }
@@ -5232,7 +8360,9 @@
         },
         "result": {
           "@type": "TestResult",
-          "outcome": "earl:inapplicable"
+          "info": "Ensures the lang attribute of the <html> element has a valid value",
+          "outcome": "earl:passed",
+          "pointer": "html"
         }
       }
     ]
@@ -5540,7 +8670,9 @@
         },
         "result": {
           "@type": "TestResult",
-          "outcome": "earl:inapplicable"
+          "info": "Ensures the lang attribute of the <html> element has a valid value",
+          "outcome": "earl:failed",
+          "pointer": "html"
         }
       }
     ]
@@ -5786,7 +8918,9 @@
         },
         "result": {
           "@type": "TestResult",
-          "outcome": "earl:inapplicable"
+          "info": "Ensures the lang attribute of the <html> element has a valid value",
+          "outcome": "earl:passed",
+          "pointer": "html"
         }
       }
     ]
@@ -6931,6 +10065,1600 @@
       }
     },
     "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_passed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures every form element has a label",
+          "outcome": "earl:passed",
+          "pointer": "input"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_passed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures every form element has a label",
+          "outcome": "earl:passed",
+          "pointer": "input"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_passed_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures every form element has a label",
+          "outcome": "earl:passed",
+          "pointer": "#country"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_passed_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures every form element has a label",
+          "outcome": "earl:passed",
+          "pointer": "textarea"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_passed_example_5.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_failed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures every form element has a label",
+          "outcome": "earl:failed",
+          "pointer": "input"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_failed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures every form element has a label",
+          "outcome": "earl:failed",
+          "pointer": "input"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_failed_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_failed_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_failed_example_5.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_failed_example_6.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_inapplicable_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_inapplicable_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_inapplicable_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures every form element has a label",
+          "outcome": "earl:failed",
+          "pointer": "input"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC3-3-2+SC4-1-2-form-field-has-name_inapplicable_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures every form element has a label",
+          "outcome": "earl:failed",
+          "pointer": "select"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-1+SC4-1-2-aria-allowed-attribute_passed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures ARIA attributes are allowed for an element's role",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-1+SC4-1-2-aria-allowed-attribute_passed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures ARIA attributes are allowed for an element's role",
+          "outcome": "earl:passed",
+          "pointer": "button"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-1+SC4-1-2-aria-allowed-attribute_passed_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-1+SC4-1-2-aria-allowed-attribute_passed_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures ARIA attributes are allowed for an element's role",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-1+SC4-1-2-aria-allowed-attribute_passed_example_5.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures ARIA attributes are allowed for an element's role",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-1+SC4-1-2-aria-allowed-attribute_passed_example_6.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures ARIA attributes are allowed for an element's role",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-1+SC4-1-2-aria-allowed-attribute_passed_example_7.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures ARIA attributes are allowed for an element's role",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-1+SC4-1-2-aria-allowed-attribute_passed_example_8.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures ARIA attributes are allowed for an element's role",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-1+SC4-1-2-aria-allowed-attribute_failed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures ARIA attributes are allowed for an element's role",
+          "outcome": "earl:failed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-1+SC4-1-2-aria-allowed-attribute_failed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures ARIA attributes are allowed for an element's role",
+          "outcome": "earl:failed",
+          "pointer": "button"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-1+SC4-1-2-aria-allowed-attribute_inapplicable_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
     "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-1-unique-id_passed_example_1.html",
     "assertions": [
       {
@@ -7895,6 +12623,2046 @@
       }
     },
     "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-attr-valid_passed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures attributes that begin with aria- are valid ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "article"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-attr-valid_passed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures attributes that begin with aria- are valid ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-attr-valid_passed_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures attributes that begin with aria- are valid ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-attr-valid_passed_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures attributes that begin with aria- are valid ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "input"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-attr-valid_failed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures attributes that begin with aria- are valid ARIA attributes",
+          "outcome": "earl:failed",
+          "pointer": "li"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-attr-valid_failed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures attributes that begin with aria- are valid ARIA attributes",
+          "outcome": "earl:failed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-attr-valid_inapplicable_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_passed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_passed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_passed_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_passed_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_passed_example_5.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:failed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_passed_example_6.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_passed_example_7.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_passed_example_8.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_passed_example_9.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_passed_example_10.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_passed_example_11.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div[role=\"scrollbar\"]"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_failed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_failed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_failed_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_failed_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_failed_example_5.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_failed_example_6.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_failed_example_7.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_failed_example_8.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_failed_example_9.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "my-button"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_failed_example_10.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_inapplicable_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_inapplicable_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_inapplicable_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_inapplicable_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-aria-state-or-property-has-valid-value_inapplicable_example_5.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
     "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-button-has-name_passed_example_1.html",
     "assertions": [
       {
@@ -8655,6 +15423,560 @@
         "test": {
           "@type": "TestCase",
           "@id": "https://dequeuniversity.com/rules/axe/3.1/button-name?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-attribute-has-valid-value_passed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures all elements with a role attribute use a valid value",
+          "outcome": "earl:passed",
+          "pointer": "input"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-attribute-has-valid-value_passed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures all elements with a role attribute use a valid value",
+          "outcome": "earl:failed",
+          "pointer": "span"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-attribute-has-valid-value_passed_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures all elements with a role attribute use a valid value",
+          "outcome": "earl:failed",
+          "pointer": "img"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-attribute-has-valid-value_failed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures all elements with a role attribute use a valid value",
+          "outcome": "earl:failed",
+          "pointer": "input"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-attribute-has-valid-value_failed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures all elements with a role attribute use a valid value",
+          "outcome": "earl:failed",
+          "pointer": "input"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-attribute-has-valid-value_inapplicable_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures all elements with a role attribute use a valid value",
+          "outcome": "earl:failed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-attribute-has-valid-value_inapplicable_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-attribute-has-valid-value_inapplicable_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures all elements with a role attribute use a valid value",
+          "outcome": "earl:failed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-attribute-has-valid-value_inapplicable_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",

--- a/output/act-axe-result.json
+++ b/output/act-axe-result.json
@@ -13076,11 +13076,11 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "info": "Ensures all ARIA attributes have valid values",
           "outcome": "earl:passed",
           "pointer": "div"
         }
@@ -13138,11 +13138,11 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "info": "Ensures all ARIA attributes have valid values",
           "outcome": "earl:passed",
           "pointer": "div"
         }
@@ -13200,11 +13200,11 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "info": "Ensures all ARIA attributes have valid values",
           "outcome": "earl:passed",
           "pointer": "div"
         }
@@ -13262,12 +13262,12 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
-          "outcome": "earl:passed",
+          "info": "Ensures all ARIA attributes have valid values",
+          "outcome": "earl:failed",
           "pointer": "div"
         }
       }
@@ -13324,11 +13324,11 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "info": "Ensures all ARIA attributes have valid values",
           "outcome": "earl:failed",
           "pointer": "div"
         }
@@ -13386,11 +13386,11 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "info": "Ensures all ARIA attributes have valid values",
           "outcome": "earl:passed",
           "pointer": "div"
         }
@@ -13448,11 +13448,11 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "info": "Ensures all ARIA attributes have valid values",
           "outcome": "earl:passed",
           "pointer": "div"
         }
@@ -13510,11 +13510,11 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "info": "Ensures all ARIA attributes have valid values",
           "outcome": "earl:passed",
           "pointer": "div"
         }
@@ -13572,11 +13572,11 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "info": "Ensures all ARIA attributes have valid values",
           "outcome": "earl:passed",
           "pointer": "div"
         }
@@ -13634,11 +13634,11 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "info": "Ensures all ARIA attributes have valid values",
           "outcome": "earl:passed",
           "pointer": "div"
         }
@@ -13696,11 +13696,11 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "info": "Ensures all ARIA attributes have valid values",
           "outcome": "earl:passed",
           "pointer": "div[role=\"scrollbar\"]"
         }
@@ -13758,12 +13758,12 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
-          "outcome": "earl:passed",
+          "info": "Ensures all ARIA attributes have valid values",
+          "outcome": "earl:failed",
           "pointer": "div"
         }
       }
@@ -13820,12 +13820,12 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
-          "outcome": "earl:passed",
+          "info": "Ensures all ARIA attributes have valid values",
+          "outcome": "earl:failed",
           "pointer": "div"
         }
       }
@@ -13882,12 +13882,12 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
-          "outcome": "earl:passed",
+          "info": "Ensures all ARIA attributes have valid values",
+          "outcome": "earl:failed",
           "pointer": "div"
         }
       }
@@ -13944,12 +13944,12 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
-          "outcome": "earl:passed",
+          "info": "Ensures all ARIA attributes have valid values",
+          "outcome": "earl:failed",
           "pointer": "div"
         }
       }
@@ -14006,12 +14006,12 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
-          "outcome": "earl:passed",
+          "info": "Ensures all ARIA attributes have valid values",
+          "outcome": "earl:failed",
           "pointer": "div"
         }
       }
@@ -14068,12 +14068,12 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
-          "outcome": "earl:passed",
+          "info": "Ensures all ARIA attributes have valid values",
+          "outcome": "earl:failed",
           "pointer": "div"
         }
       }
@@ -14130,12 +14130,12 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
-          "outcome": "earl:passed",
+          "info": "Ensures all ARIA attributes have valid values",
+          "outcome": "earl:failed",
           "pointer": "div"
         }
       }
@@ -14192,12 +14192,12 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
-          "outcome": "earl:passed",
+          "info": "Ensures all ARIA attributes have valid values",
+          "outcome": "earl:failed",
           "pointer": "div"
         }
       }
@@ -14254,12 +14254,12 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
-          "outcome": "earl:passed",
+          "info": "Ensures all ARIA attributes have valid values",
+          "outcome": "earl:failed",
           "pointer": "my-button"
         }
       }
@@ -14316,12 +14316,12 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
-          "outcome": "earl:passed",
+          "info": "Ensures all ARIA attributes have valid values",
+          "outcome": "earl:failed",
           "pointer": "div"
         }
       }
@@ -14378,7 +14378,7 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
@@ -14438,13 +14438,11 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
-          "outcome": "earl:passed",
-          "pointer": "div"
+          "outcome": "earl:inapplicable"
         }
       }
     ]
@@ -14500,12 +14498,12 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
-          "outcome": "earl:passed",
+          "info": "Ensures all ARIA attributes have valid values",
+          "outcome": "earl:failed",
           "pointer": "div"
         }
       }
@@ -14562,11 +14560,11 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
-          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "info": "Ensures all ARIA attributes have valid values",
           "outcome": "earl:passed",
           "pointer": "div"
         }
@@ -14624,7 +14622,7 @@
         },
         "test": {
           "@type": "TestCase",
-          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI"
         },
         "result": {
           "@type": "TestResult",
@@ -15461,6 +15459,684 @@
       }
     },
     "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-iframe-has-name_passed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/frame-title?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
+          "outcome": "earl:passed",
+          "pointer": "iframe"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-iframe-has-name_passed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/frame-title?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
+          "outcome": "earl:passed",
+          "pointer": "iframe"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-iframe-has-name_passed_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/frame-title?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
+          "outcome": "earl:passed",
+          "pointer": "iframe"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-iframe-has-name_failed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/frame-title?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
+          "outcome": "earl:failed",
+          "pointer": "iframe"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-iframe-has-name_failed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/frame-title?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
+          "outcome": "earl:failed",
+          "pointer": "iframe"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-iframe-has-name_failed_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/frame-title?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
+          "outcome": "earl:failed",
+          "pointer": "iframe"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-iframe-has-name_failed_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/frame-title?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
+          "outcome": "earl:failed",
+          "pointer": "iframe"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-iframe-has-name_failed_example_5.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/frame-title?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
+          "outcome": "earl:failed",
+          "pointer": "iframe"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-iframe-has-name_failed_example_6.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/frame-title?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
+          "outcome": "earl:failed",
+          "pointer": "iframe"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-iframe-has-name_inapplicable_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/frame-title?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-iframe-has-name_inapplicable_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/frame-title?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
     "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-attribute-has-valid-value_passed_example_1.html",
     "assertions": [
       {
@@ -15981,6 +16657,684 @@
         "result": {
           "@type": "TestResult",
           "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-has-required-states-and-properties_passed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-has-required-states-and-properties_passed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-has-required-states-and-properties_passed_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-has-required-states-and-properties_passed_example_4.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-has-required-states-and-properties_passed_example_5.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:failed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-has-required-states-and-properties_passed_example_6.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:failed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-has-required-states-and-properties_failed_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:failed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-has-required-states-and-properties_failed_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:failed",
+          "pointer": "div"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-has-required-states-and-properties_inapplicable_example_1.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-has-required-states-and-properties_inapplicable_example_2.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "outcome": "earl:inapplicable"
+        }
+      }
+    ]
+  },
+  {
+    "@context": {
+      "@vocab": "http://www.w3.org/ns/earl#",
+      "earl": "http://www.w3.org/ns/earl#",
+      "WCAG20": "http://www.w3.org/TR/WCAG20/#",
+      "WCAG21": "http://www.w3.org/TR/WCAG21/#",
+      "auto-wcag": "https://auto-wcag.github.io/auto-wcag/rules/",
+      "dct": "http://purl.org/dc/terms#",
+      "sch": "https://schema.org/",
+      "doap": "http://usefulinc.com/ns/doap#",
+      "foaf": "http://xmlns.com/foaf/spec/#",
+      "WebPage": "sch:WebPage",
+      "url": "dct:source",
+      "assertions": {
+        "@reverse": "subject"
+      },
+      "assertedBy": {
+        "@type": "@id"
+      },
+      "outcome": {
+        "@type": "@id"
+      },
+      "mode": {
+        "@type": "@id"
+      },
+      "pointer": {
+        "@type": "ptr:CSSSelectorPointer"
+      }
+    },
+    "@type": "WebPage",
+    "url": "https://auto-wcag.github.io/auto-wcag/auto-wcag-testcases/assets/SC4-1-2-role-has-required-states-and-properties_inapplicable_example_3.html",
+    "assertions": [
+      {
+        "@type": "Assertion",
+        "mode": "earl:automatic",
+        "assertedBy": {
+          "@id": "https://github.com/dequelabs/axe-core/releases/tag/3.1.0",
+          "@type": [
+            "earl:Assertor",
+            "earl:Software",
+            "doap:Project"
+          ],
+          "doap:name": "Axe",
+          "doap:vendor": {
+            "@id": "https://deque.com/",
+            "@type": "foaf:Organization",
+            "foaf:name": "Deque Systems"
+          }
+        },
+        "test": {
+          "@type": "TestCase",
+          "@id": "https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=axeAPI"
+        },
+        "result": {
+          "@type": "TestResult",
+          "info": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "outcome": "earl:passed",
+          "pointer": "input"
         }
       }
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,9 +98,9 @@
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "axe-core": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.1.2.tgz",
-      "integrity": "sha512-e1WVs0SQu3tM29J9a/mISGvlo2kdCStE+yffIAJF6eb42FS+eUFEVz9j4rgDeV2TAfPJmuOZdRetWYycIbK7Vg=="
+      "version": "3.1.2-canary.e24cea9",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.1.2-canary.e24cea9.tgz",
+      "integrity": "sha512-+IT7+9ifYqWZrVQZsW9NRnPW4BDRFd9woCbXuvWmeZzqLGHZBq1rBsILsCXWCz3fpW/ElsARfll6mjpuOHt61w=="
     },
     "axe-reporter-earl": {
       "version": "0.1.0-canary.be38c0de",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/dequelabs/axe-act-testrunner#readme",
   "dependencies": {
-    "axe-core": "^3.1.2-canary.e67fc65",
+    "axe-core": "^3.1.2-canary.e24cea9",
     "axe-reporter-earl": "0.1.0-canary.be38c0de",
     "fs-extra": "^7.0.0",
     "testrunner": "git+https://github.com/auto-wcag/testrunner.git#master"

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,6 +1,7 @@
 const axePath = require.resolve('axe-core')
 const { createEarlReport } = require('axe-reporter-earl')
 const { skipTests } = require('./skip-tests')
+const { runOnly } = require('./run-only')
 const { rulesMap } = require('./rules-map')
 const { evaluate } = require('./evaluate')
 
@@ -14,6 +15,11 @@ const configuration = {
    * List of tests to be skipped by the testrunner
    */
   skipTests, // tests to skip
+
+  /**
+   * Run only these tests if specified
+   */
+  runOnly,
 
   /**
    * List of scripts to be injected into the testrunner(s) page instance

--- a/src/rules-map.js
+++ b/src/rules-map.js
@@ -16,10 +16,10 @@ const rulesMap = {
   'SC1-2-video-description-track': ['video-description'],
   'SC1-2-video-transcript': ['video-caption', 'video-description'],
   'SC1-3-5-autocomplete-valid': ['autocomplete-valid'],
-  // 'SC2-1-2-no-keyboard-trap-non-standard-navigation': [],
-  // 'SC2-1-2-no-keyboard-trap-standard-navigation': [],
-  // 'SC2-1-2-no-keyboard-trap': [],
-  // 'SC2-2-1+SC2-2-4-meta-refresh': ['meta-refresh'],
+  'SC2-1-2-no-keyboard-trap-non-standard-navigation': [],
+  'SC2-1-2-no-keyboard-trap-standard-navigation': [],
+  'SC2-1-2-no-keyboard-trap': [],
+  // 'SC2-2-1+SC2-2-4-meta-refresh': ['meta-refresh'], // TODO: go through test cases to handle
   'SC2-4-2-page-has-title': ['document-title'],
   'SC2-4-4-link-has-name': ['link-name'],
   'SC2-4-6-descriptive-headings': [],
@@ -39,11 +39,11 @@ const rulesMap = {
   'SC4-1-1+SC4-1-2-aria-allowed-attribute': ['aria-allowed-attr'],
   'SC4-1-2-aria-attr-valid': ['aria-valid-attr'],
   'SC4-1-2-aria-hidden-focus': [],
-  'SC4-1-2-aria-state-or-property-has-valid-value': ['aria-required-attr'],
+  'SC4-1-2-aria-state-or-property-has-valid-value': ['aria-valid-attr-value'],
   'SC4-1-2-button-has-name': ['button-name'],
-  'SC4-1-2-iframe-has-name': [],
+  'SC4-1-2-iframe-has-name': ['frame-title'],
   'SC4-1-2-role-attribute-has-valid-value': ['aria-roles'],
-  'SC4-1-2-role-has-required-states-and-properties': []
+  'SC4-1-2-role-has-required-states-and-properties': ['aria-required-attr']
 }
 
 // export

--- a/src/rules-map.js
+++ b/src/rules-map.js
@@ -7,23 +7,43 @@
  */
 const rulesMap = {
   'SC1-1-1-image-has-name': ['image-alt'],
+  'SC1-2-1-media-alternative-audio': ['video-caption', 'video-description'],
+  'SC1-2-1-media-alternative-video': ['video-caption', 'video-description'],
   'SC1-2-2-audio-captions': ['audio-caption'],
-  'SC1-2-Video-description-track': ['video-description'],
+  'SC1-2-2-video-has-audio-alternative': ['video-caption', 'video-description'],
+  'SC1-2-2-video-has-captions': ['video-caption'],
+  'SC1-2-video-audio-description': ['video-caption', 'video-description'],
+  'SC1-2-video-description-track': ['video-description'],
+  'SC1-2-video-transcript': ['video-caption', 'video-description'],
+  'SC1-3-5-autocomplete-valid': ['autocomplete-valid'],
+  // 'SC2-1-2-no-keyboard-trap-non-standard-navigation': [],
+  // 'SC2-1-2-no-keyboard-trap-standard-navigation': [],
+  // 'SC2-1-2-no-keyboard-trap': [],
+  // 'SC2-2-1+SC2-2-4-meta-refresh': ['meta-refresh'],
   'SC2-4-2-page-has-title': ['document-title'],
   'SC2-4-4-link-has-name': ['link-name'],
+  'SC2-4-6-descriptive-headings': [],
+  'SC2-4-6-descriptive-labels': [],
+  'SC2-5-3-label-content-name-mismatch': [],
   'SC3-1-1-html-has-lang': ['html-has-lang'],
   'SC3-1-1-html-lang-valid': ['html-lang-valid'],
   'SC3-1-1-html-xml-lang-match': ['html-xml-lang-mismatch'],
   'SC3-1-2-lang-valid': ['valid-lang'],
-  'SC3-3-2-form-field-has-name': ['label'],
+  'SC3-3-2+SC4-1-2-form-field-has-name': ['label'],
+  'SC4-1-1-unique-attrs': [],
   'SC4-1-1-unique-id': [
     'duplicate-id',
     'duplicate-id-active',
     'duplicate-id-aria'
   ],
+  'SC4-1-1+SC4-1-2-aria-allowed-attribute': ['aria-allowed-attr'],
+  'SC4-1-2-aria-attr-valid': ['aria-valid-attr'],
+  'SC4-1-2-aria-hidden-focus': [],
+  'SC4-1-2-aria-state-or-property-has-valid-value': ['aria-required-attr'],
   'SC4-1-2-button-has-name': ['button-name'],
-  'SC1-3-5-autocomplete-valid': ['autocomplete-valid'],
-  'SC2-2-1+SC3-2-5-meta-refresh': ['meta-refresh']
+  'SC4-1-2-iframe-has-name': [],
+  'SC4-1-2-role-attribute-has-valid-value': ['aria-roles'],
+  'SC4-1-2-role-has-required-states-and-properties': []
 }
 
 // export

--- a/src/run-only.js
+++ b/src/run-only.js
@@ -1,0 +1,11 @@
+/**
+ * Only run these rules
+ *
+ * List of file names of test cases eg: 'SC3-3-2+SC4-1-2-form-field-has-name_inapplicable_example_4.html'
+ */
+const runOnly = []
+
+// export
+module.exports = {
+  runOnly
+}

--- a/src/skip-tests.js
+++ b/src/skip-tests.js
@@ -4,6 +4,7 @@
  * Allows to skip in two modes:
  * 1) ruleIds: skips entire Auto-WCAG rule, and the test cases under it.
  * 2) testCases: specific test cases under a Auto-WCAG rule.
+ * 3) fileExtensions: skip files with these extensions
  */
 const skipTests = {
   ruleIds: [


### PR DESCRIPTION
Ideally this PR - https://github.com/auto-wcag/testrunner/pull/4, needs to land before this one.

This PR does the below:

- Update the mapping of ACT rules with Axe rules and generates a newer report - https://github.com/dequelabs/axe-act-testrunner/pull/3/files#diff-0f55fc2f2f8388a0278ca3507f2dbac1, this will be consumed by auto wcag.
- Introduces a `runOnly` configuration option to easily filter test cases to run.